### PR TITLE
fix: only include alias in index if not deleted

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ package-lock.json
 **/docs/reference
 **/docs/open-api
 changelog.md
+**/schemas

--- a/packages/auditable-item-graph-models/src/schemas/AuditableItemGraphAlias.json
+++ b/packages/auditable-item-graph-models/src/schemas/AuditableItemGraphAlias.json
@@ -53,7 +53,11 @@
 			"description": "The format of the id in the alias."
 		}
 	},
-	"required": ["@context", "id", "type"],
+	"required": [
+		"@context",
+		"id",
+		"type"
+	],
 	"additionalProperties": false,
 	"description": "Interface describing an alias for a vertex."
 }

--- a/packages/auditable-item-graph-models/src/schemas/AuditableItemGraphChangeset.json
+++ b/packages/auditable-item-graph-models/src/schemas/AuditableItemGraphChangeset.json
@@ -52,7 +52,14 @@
 			"description": "The verification for the changeset."
 		}
 	},
-	"required": ["@context", "type", "id", "dateCreated", "userIdentity", "patches"],
+	"required": [
+		"@context",
+		"type",
+		"id",
+		"dateCreated",
+		"userIdentity",
+		"patches"
+	],
 	"additionalProperties": false,
 	"description": "Interface describing a set of changes to the vertex."
 }

--- a/packages/auditable-item-graph-models/src/schemas/AuditableItemGraphEdge.json
+++ b/packages/auditable-item-graph-models/src/schemas/AuditableItemGraphEdge.json
@@ -56,7 +56,12 @@
 			"description": "The relationships between the two vertices."
 		}
 	},
-	"required": ["@context", "id", "type", "edgeRelationships"],
+	"required": [
+		"@context",
+		"id",
+		"type",
+		"edgeRelationships"
+	],
 	"additionalProperties": false,
 	"description": "Interface describing an edge between two vertices in an auditable item graph."
 }

--- a/packages/auditable-item-graph-models/src/schemas/AuditableItemGraphPatchOperation.json
+++ b/packages/auditable-item-graph-models/src/schemas/AuditableItemGraphPatchOperation.json
@@ -30,7 +30,14 @@
 		},
 		"patchOperation": {
 			"type": "string",
-			"enum": ["add", "remove", "replace", "move", "copy", "test"],
+			"enum": [
+				"add",
+				"remove",
+				"replace",
+				"move",
+				"copy",
+				"test"
+			],
 			"description": "The operation that was performed on the item."
 		},
 		"patchPath": {
@@ -45,7 +52,12 @@
 			"description": "The value to add."
 		}
 	},
-	"required": ["@context", "type", "patchOperation", "patchPath"],
+	"required": [
+		"@context",
+		"type",
+		"patchOperation",
+		"patchPath"
+	],
 	"additionalProperties": false,
 	"description": "The patch operation for JSON diffs."
 }

--- a/packages/auditable-item-graph-models/src/schemas/AuditableItemGraphResource.json
+++ b/packages/auditable-item-graph-models/src/schemas/AuditableItemGraphResource.json
@@ -49,7 +49,10 @@
 			"description": "The JSON-LD object for the resource."
 		}
 	},
-	"required": ["@context", "type"],
+	"required": [
+		"@context",
+		"type"
+	],
 	"additionalProperties": false,
 	"description": "Interface describing an auditable item graph vertex resource."
 }

--- a/packages/auditable-item-graph-models/src/schemas/AuditableItemGraphVertex.json
+++ b/packages/auditable-item-graph-models/src/schemas/AuditableItemGraphVertex.json
@@ -81,7 +81,11 @@
 			"description": "Is the vertex verified, will only be populated when verification is requested."
 		}
 	},
-	"required": ["@context", "id", "type"],
+	"required": [
+		"@context",
+		"id",
+		"type"
+	],
 	"additionalProperties": false,
 	"description": "Interface describing an auditable item graph vertex."
 }

--- a/packages/auditable-item-graph-models/src/schemas/AuditableItemGraphVertexList.json
+++ b/packages/auditable-item-graph-models/src/schemas/AuditableItemGraphVertexList.json
@@ -40,7 +40,11 @@
 			"description": "The cursor to get the next chunk of vertices."
 		}
 	},
-	"required": ["@context", "type", "vertices"],
+	"required": [
+		"@context",
+		"type",
+		"vertices"
+	],
 	"additionalProperties": false,
 	"description": "Interface describing an auditable item graph vertex list."
 }

--- a/packages/auditable-item-graph-rest-client/docs/reference/classes/AuditableItemGraphClient.md
+++ b/packages/auditable-item-graph-rest-client/docs/reference/classes/AuditableItemGraphClient.md
@@ -1,0 +1,273 @@
+# Class: AuditableItemGraphClient
+
+Client for performing auditable item graph through to REST endpoints.
+
+## Extends
+
+- `BaseRestClient`
+
+## Implements
+
+- `IAuditableItemGraphComponent`
+
+## Constructors
+
+### new AuditableItemGraphClient()
+
+> **new AuditableItemGraphClient**(`config`): [`AuditableItemGraphClient`](AuditableItemGraphClient.md)
+
+Create a new instance of AuditableItemGraphClient.
+
+#### Parameters
+
+##### config
+
+`IBaseRestClientConfig`
+
+The configuration for the client.
+
+#### Returns
+
+[`AuditableItemGraphClient`](AuditableItemGraphClient.md)
+
+#### Overrides
+
+`BaseRestClient.constructor`
+
+## Properties
+
+### CLASS\_NAME
+
+> `readonly` **CLASS\_NAME**: `string`
+
+Runtime name for the class.
+
+#### Implementation of
+
+`IAuditableItemGraphComponent.CLASS_NAME`
+
+## Methods
+
+### create()
+
+> **create**(`vertex`): `Promise`\<`string`\>
+
+Create a new graph vertex.
+
+#### Parameters
+
+##### vertex
+
+The vertex to create.
+
+###### annotationObject?
+
+`IJsonLdNodeObject`
+
+The annotation object for the vertex as JSON-LD.
+
+###### aliases?
+
+`object`[]
+
+Alternative aliases that can be used to identify the vertex.
+
+###### resources?
+
+`object`[]
+
+The resources attached to the vertex.
+
+###### edges?
+
+`object`[]
+
+The edges connected to the vertex.
+
+#### Returns
+
+`Promise`\<`string`\>
+
+The id of the new graph item.
+
+#### Implementation of
+
+`IAuditableItemGraphComponent.create`
+
+***
+
+### get()
+
+> **get**(`id`, `options`?): `Promise`\<`IAuditableItemGraphVertex`\>
+
+Get a graph vertex.
+
+#### Parameters
+
+##### id
+
+`string`
+
+The id of the vertex to get.
+
+##### options?
+
+Additional options for the get operation.
+
+###### includeDeleted?
+
+`boolean`
+
+Whether to include deleted/updated aliases, resource, edges, defaults to false.
+
+###### includeChangesets?
+
+`boolean`
+
+Whether to include the changesets of the vertex, defaults to false.
+
+###### verifySignatureDepth?
+
+`VerifyDepth`
+
+How many signatures to verify, defaults to "none".
+
+#### Returns
+
+`Promise`\<`IAuditableItemGraphVertex`\>
+
+The vertex if found.
+
+#### Throws
+
+NotFoundError if the vertex is not found.
+
+#### Implementation of
+
+`IAuditableItemGraphComponent.get`
+
+***
+
+### update()
+
+> **update**(`vertex`): `Promise`\<`void`\>
+
+Update a graph vertex.
+
+#### Parameters
+
+##### vertex
+
+The vertex to update.
+
+###### id
+
+`string`
+
+The id of the vertex to update.
+
+###### annotationObject?
+
+`IJsonLdNodeObject`
+
+The annotation object for the vertex as JSON-LD.
+
+###### aliases?
+
+`object`[]
+
+Alternative aliases that can be used to identify the vertex.
+
+###### resources?
+
+`object`[]
+
+The resources attached to the vertex.
+
+###### edges?
+
+`object`[]
+
+The edges connected to the vertex.
+
+#### Returns
+
+`Promise`\<`void`\>
+
+Nothing.
+
+#### Implementation of
+
+`IAuditableItemGraphComponent.update`
+
+***
+
+### query()
+
+> **query**(`options`?, `conditions`?, `orderBy`?, `orderByDirection`?, `properties`?, `cursor`?, `pageSize`?): `Promise`\<`IAuditableItemGraphVertexList`\>
+
+Query the graph for vertices.
+
+#### Parameters
+
+##### options?
+
+The query options.
+
+###### id?
+
+`string`
+
+The optional id to look for.
+
+###### idMode?
+
+`"both"` \| `"id"` \| `"alias"`
+
+Look in id, alias or both, defaults to both.
+
+##### conditions?
+
+`IComparator`[]
+
+Conditions to use in the query.
+
+##### orderBy?
+
+The order for the results, defaults to created.
+
+`"dateCreated"` | `"dateModified"`
+
+##### orderByDirection?
+
+`SortDirection`
+
+The direction for the order, defaults to descending.
+
+##### properties?
+
+keyof `IAuditableItemGraphVertex`[]
+
+The properties to return, if not provided defaults to id, created, aliases and object.
+
+##### cursor?
+
+`string`
+
+The cursor to request the next page of entities.
+
+##### pageSize?
+
+`number`
+
+The maximum number of entities in a page.
+
+#### Returns
+
+`Promise`\<`IAuditableItemGraphVertexList`\>
+
+The entities, which can be partial if a limited keys list was provided.
+
+#### Implementation of
+
+`IAuditableItemGraphComponent.query`

--- a/packages/auditable-item-graph-rest-client/docs/reference/index.md
+++ b/packages/auditable-item-graph-rest-client/docs/reference/index.md
@@ -1,0 +1,5 @@
+# @twin.org/auditable-item-graph-rest-client
+
+## Classes
+
+- [AuditableItemGraphClient](classes/AuditableItemGraphClient.md)

--- a/packages/auditable-item-graph-service/src/auditableItemGraphService.ts
+++ b/packages/auditable-item-graph-service/src/auditableItemGraphService.ts
@@ -213,7 +213,8 @@ export class AuditableItemGraphService implements IAuditableItemGraphComponent {
 			await this._vertexStorage.set({
 				...vertexModel,
 				aliasIndex: vertexModel.aliases
-					?.map(a => a.id)
+					?.filter(a => Is.empty(a.dateDeleted))
+					.map(a => a.id)
 					.join("||")
 					.toLowerCase()
 			});
@@ -410,7 +411,8 @@ export class AuditableItemGraphService implements IAuditableItemGraphComponent {
 				await this._vertexStorage.set({
 					...newEntity,
 					aliasIndex: newEntity.aliases
-						?.map(a => a.id)
+						?.filter(a => Is.empty(a.dateDeleted))
+						.map(a => a.id)
 						.join("||")
 						.toLowerCase()
 				});


### PR DESCRIPTION
The aliasIndex is generated whenever the vertex is updated, but if an alias was deleted it was still included in the index. Index creation now excludes aliases with the dateDeleted set.