### PR TITLE
fix: update tests with new deterministic background tasks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -536,9 +536,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-aws": {
-			"version": "4.0.9",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.9.tgz",
-			"integrity": "sha512-bDYdnnJGwSkIZ4gzrauu7qzOs/ZAY/FnU4k11LgdMI8BhwMfsbsy2EI1iS+sD/BI5ZnNT9kU5YR3WADeNOmhRg==",
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-4.0.10.tgz",
+			"integrity": "sha512-0qW4sI0GX8haELdhfakQNuw7a2pnWXz3VYQA2MpydH2xT2e6EN9DWFpKAi8DfcChm8MgDAogKkoHtIo075iYng==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -560,9 +560,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-cpp": {
-			"version": "6.0.6",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-6.0.6.tgz",
-			"integrity": "sha512-HMV1chsExuZt5IL9rYBW7GmhNZDVdQJEd1WtFgOO6jqiNxbpTG3Is3Pkldl7FpusBQQZr4BdjMit5bnPpVRy3A==",
+			"version": "6.0.8",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-6.0.8.tgz",
+			"integrity": "sha512-BzurRZilWqaJt32Gif6/yCCPi+FtrchjmnehVEIFzbWyeBd/VOUw77IwrEzehZsu5cRU91yPWuWp5fUsKfDAXA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -595,9 +595,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-data-science": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.7.tgz",
-			"integrity": "sha512-XhAkK+nSW6zmrnWzusmZ1BpYLc62AWYHZc2p17u4nE2Z9XG5DleG55PCZxXQTKz90pmwlhFM9AfpkJsYaBWATA==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-2.0.8.tgz",
+			"integrity": "sha512-uyAtT+32PfM29wRBeAkUSbkytqI8bNszNfAz2sGPtZBRmsZTYugKMEO9eDjAIE/pnT9CmbjNuoiXhk+Ss4fCOg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -609,9 +609,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-docker": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.12.tgz",
-			"integrity": "sha512-6d25ZPBnYZaT9D9An/x6g/4mk542R8bR3ipnby3QFCxnfdd6xaWiTcwDPsCgwN2aQZIQ1jX/fil9KmBEqIK/qA==",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.13.tgz",
+			"integrity": "sha512-85X+ZC/CPT3ie26DcfeMFkZSNuhS8DlAqPXzAjilHtGE/Nj+QnS3jyBz0spDJOJrjh8wx1+ro2oCK98sbVcztw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -630,9 +630,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-en_us": {
-			"version": "4.3.35",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.35.tgz",
-			"integrity": "sha512-HF6QNyPHkxeo/SosaZXRQlnKDUTjIzrGKyqfbw/fPPlPYrXefAZZ40ofheb5HnbUicR7xqV/lsc/HQfqYshGIw==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.0.tgz",
+			"integrity": "sha512-TEfVT2NwvI9k1/ECjuC7GbULxenjJAbTLWMri1eMRk3mRGtqg5j0XzvvNRFuJWq8X48MdGVjsD+ZVI/VR94+eQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -686,9 +686,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-gaming-terms": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.1.0.tgz",
-			"integrity": "sha512-46AnDs9XkgJ2f1Sqol1WgfJ8gOqp60fojpc9Wxch7x+BA63g4JfMV5/M5x0sI0TLlLY8EBSglcr8wQF/7C80AQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.1.1.tgz",
+			"integrity": "sha512-tb8GFxjTLDQstkJcJ90lDqF4rKKlMUKs5/ewePN9P+PYRSehqDpLI5S5meOfPit8LGszeOrjUdBQ4zXo7NpMyQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -700,9 +700,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-golang": {
-			"version": "6.0.19",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.19.tgz",
-			"integrity": "sha512-VS+oinB2/CbgmHE06kMJlj52OVMZM0S2EEXph3oaroNTgTuclSwdFylQmOEjquZi55kW+n3FM9MyWXiitB7Dtg==",
+			"version": "6.0.20",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.20.tgz",
+			"integrity": "sha512-b7nd9XXs+apMMzNSWorjirQsbmlwcTC0ViQJU8u+XNose3z0y7oNeEpbTPTVoN1+1sO9aOHuFwfwoOMFCDS14Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -791,16 +791,16 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-markdown": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.9.tgz",
-			"integrity": "sha512-j2e6Eg18BlTb1mMP1DkyRFMM/FLS7qiZjltpURzDckB57zDZbUyskOFdl4VX7jItZZEeY0fe22bSPOycgS1Z5A==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.10.tgz",
+			"integrity": "sha512-vtVa6L/84F9sTjclTYDkWJF/Vx2c5xzxBKkQp+CEFlxOF2SYgm+RSoEvAvg5vj4N5kuqR4350ZlY3zl2eA3MXw==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"@cspell/dict-css": "^4.0.17",
 				"@cspell/dict-html": "^4.0.11",
 				"@cspell/dict-html-symbol-entities": "^4.0.3",
-				"@cspell/dict-typescript": "^3.2.0"
+				"@cspell/dict-typescript": "^3.2.1"
 			}
 		},
 		"node_modules/@cspell/dict-monkeyc": {
@@ -811,16 +811,16 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-node": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.6.tgz",
-			"integrity": "sha512-CEbhPCpxGvRNByGolSBTrXXW2rJA4bGqZuTx1KKO85mwR6aadeOmUE7xf/8jiCkXSy+qvr9aJeh+jlfXcsrziQ==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-5.0.7.tgz",
+			"integrity": "sha512-ZaPpBsHGQCqUyFPKLyCNUH2qzolDRm1/901IO8e7btk7bEDF56DN82VD43gPvD4HWz3yLs/WkcLa01KYAJpnOw==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-npm": {
-			"version": "5.1.31",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.31.tgz",
-			"integrity": "sha512-Oh9nrhgNV4UD1hlbgO3TFQqQRKziwc7qXKoQiC4oqOYIhMs2WL9Ezozku7FY1e7o5XbCIZX9nRH0ymNx/Rwj6w==",
+			"version": "5.1.34",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.1.34.tgz",
+			"integrity": "sha512-UrUYqRQX864Cx9QJkg7eEIxmjYGqcje+x1j7bzl+a3jCKwT6jm+p0off6VEOf3EReHP0dWUSYO3Q0+pLL/N+FQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -846,13 +846,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-python": {
-			"version": "4.2.16",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.16.tgz",
-			"integrity": "sha512-LkQssFt1hPOWXIQiD8ScTkz/41RL7Ti0V/2ytUzEW82dc0atIEksrBg8MuOjWXktp0Dk5tDwRLgmIvhV3CFFOA==",
+			"version": "4.2.17",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.17.tgz",
+			"integrity": "sha512-xqMKfVc8d7yDaOChFdL2uWAN3Mw9qObB/Zr6t5w1OHbi23gWs7V1lI9d0mXAoqSK6N3mosbum4OIq/FleQDnlw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@cspell/dict-data-science": "^2.0.7"
+				"@cspell/dict-data-science": "^2.0.8"
 			}
 		},
 		"node_modules/@cspell/dict-r": {
@@ -926,9 +926,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-typescript": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.0.tgz",
-			"integrity": "sha512-Pk3zNePLT8qg51l0M4g1ISowYAEGxTuNfZlgkU5SvHa9Cu7x/BWoyYq9Fvc3kAyoisCjRPyvWF4uRYrPitPDFw==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.1.tgz",
+			"integrity": "sha512-jdnKg4rBl75GUBTsUD6nTJl7FGvaIt5wWcWP7TZSC3rV1LfkwvbUiY3PiGpfJlAIdnLYSeFWIpYU9gyVgz206w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1013,9 +1013,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.1.tgz",
-			"integrity": "sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz",
+			"integrity": "sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1030,9 +1030,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.1.tgz",
-			"integrity": "sha512-dp+MshLYux6j/JjdqVLnMglQlFu+MuVeNrmT5nk6q07wNhCdSnB7QZj+7G8VMUGh1q+vj2Bq8kRsuyA00I/k+Q==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.2.tgz",
+			"integrity": "sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==",
 			"cpu": [
 				"arm"
 			],
@@ -1047,9 +1047,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.1.tgz",
-			"integrity": "sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.2.tgz",
+			"integrity": "sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==",
 			"cpu": [
 				"arm64"
 			],
@@ -1064,9 +1064,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.1.tgz",
-			"integrity": "sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.2.tgz",
+			"integrity": "sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==",
 			"cpu": [
 				"x64"
 			],
@@ -1081,9 +1081,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.1.tgz",
-			"integrity": "sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.2.tgz",
+			"integrity": "sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1098,9 +1098,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.1.tgz",
-			"integrity": "sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.2.tgz",
+			"integrity": "sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==",
 			"cpu": [
 				"x64"
 			],
@@ -1115,9 +1115,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.1.tgz",
-			"integrity": "sha512-1MrCZs0fZa2g8E+FUo2ipw6jw5qqQiH+tERoS5fAfKnRx6NXH31tXBKI3VpmLijLH6yriMZsxJtaXUyFt/8Y4A==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.2.tgz",
+			"integrity": "sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==",
 			"cpu": [
 				"arm64"
 			],
@@ -1132,9 +1132,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.1.tgz",
-			"integrity": "sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.2.tgz",
+			"integrity": "sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1149,9 +1149,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.1.tgz",
-			"integrity": "sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.2.tgz",
+			"integrity": "sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==",
 			"cpu": [
 				"arm"
 			],
@@ -1166,9 +1166,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.1.tgz",
-			"integrity": "sha512-jaN3dHi0/DDPelk0nLcXRm1q7DNJpjXy7yWaWvbfkPvI+7XNSc/lDOnCLN7gzsyzgu6qSAmgSvP9oXAhP973uQ==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.2.tgz",
+			"integrity": "sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==",
 			"cpu": [
 				"arm64"
 			],
@@ -1183,9 +1183,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.1.tgz",
-			"integrity": "sha512-OJykPaF4v8JidKNGz8c/q1lBO44sQNUQtq1KktJXdBLn1hPod5rE/Hko5ugKKZd+D2+o1a9MFGUEIUwO2YfgkQ==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.2.tgz",
+			"integrity": "sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -1200,9 +1200,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.1.tgz",
-			"integrity": "sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.2.tgz",
+			"integrity": "sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==",
 			"cpu": [
 				"loong64"
 			],
@@ -1217,9 +1217,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.1.tgz",
-			"integrity": "sha512-1osBbPEFYwIE5IVB/0g2X6i1qInZa1aIoj1TdL4AaAb55xIIgbg8Doq6a5BzYWgr+tEcDzYH67XVnTmUzL+nXg==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.2.tgz",
+			"integrity": "sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==",
 			"cpu": [
 				"mips64el"
 			],
@@ -1234,9 +1234,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.1.tgz",
-			"integrity": "sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.2.tgz",
+			"integrity": "sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1251,9 +1251,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.1.tgz",
-			"integrity": "sha512-nSut/Mx5gnilhcq2yIMLMe3Wl4FK5wx/o0QuuCLMtmJn+WeWYoEGDN1ipcN72g1WHsnIbxGXd4i/MF0gTcuAjQ==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.2.tgz",
+			"integrity": "sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1268,9 +1268,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.1.tgz",
-			"integrity": "sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.2.tgz",
+			"integrity": "sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==",
 			"cpu": [
 				"s390x"
 			],
@@ -1285,9 +1285,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.1.tgz",
-			"integrity": "sha512-xbfUhu/gnvSEg+EGovRc+kjBAkrvtk38RlerAzQxvMzlB4fXpCFCeUAYzJvrnhFtdeyVCDANSjJvOvGYoeKzFA==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.2.tgz",
+			"integrity": "sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==",
 			"cpu": [
 				"x64"
 			],
@@ -1302,9 +1302,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.1.tgz",
-			"integrity": "sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.2.tgz",
+			"integrity": "sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1319,9 +1319,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.1.tgz",
-			"integrity": "sha512-X53z6uXip6KFXBQ+Krbx25XHV/NCbzryM6ehOAeAil7X7oa4XIq+394PWGnwaSQ2WRA0KI6PUO6hTO5zeF5ijA==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.2.tgz",
+			"integrity": "sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==",
 			"cpu": [
 				"x64"
 			],
@@ -1336,9 +1336,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.1.tgz",
-			"integrity": "sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.2.tgz",
+			"integrity": "sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1353,9 +1353,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.1.tgz",
-			"integrity": "sha512-T3H78X2h1tszfRSf+txbt5aOp/e7TAz3ptVKu9Oyir3IAOFPGV6O9c2naym5TOriy1l0nNf6a4X5UXRZSGX/dw==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.2.tgz",
+			"integrity": "sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==",
 			"cpu": [
 				"x64"
 			],
@@ -1370,9 +1370,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.1.tgz",
-			"integrity": "sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.2.tgz",
+			"integrity": "sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==",
 			"cpu": [
 				"x64"
 			],
@@ -1387,9 +1387,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.1.tgz",
-			"integrity": "sha512-GE7XvrdOzrb+yVKB9KsRMq+7a2U/K5Cf/8grVFRAGJmfADr/e/ODQ134RK2/eeHqYV5eQRFxb1hY7Nr15fv1NQ==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.2.tgz",
+			"integrity": "sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -1404,9 +1404,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.1.tgz",
-			"integrity": "sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.2.tgz",
+			"integrity": "sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==",
 			"cpu": [
 				"ia32"
 			],
@@ -1421,9 +1421,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.1.tgz",
-			"integrity": "sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.2.tgz",
+			"integrity": "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==",
 			"cpu": [
 				"x64"
 			],
@@ -2165,26 +2165,6 @@
 				}
 			}
 		},
-		"node_modules/@rollup/pluginutils/node_modules/estree-walker": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@rollup/pluginutils/node_modules/picomatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.34.9",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.9.tgz",
@@ -2572,13 +2552,13 @@
 			"link": true
 		},
 		"node_modules/@twin.org/background-task-connector-entity-storage": {
-			"version": "0.0.1-next.13",
-			"resolved": "https://registry.npmjs.org/@twin.org/background-task-connector-entity-storage/-/background-task-connector-entity-storage-0.0.1-next.13.tgz",
-			"integrity": "sha512-aKRLFys4i0NGA/8Q4SQsh7le8yxsPlemNCX2NehPLjyQS0qYigziZrLQ1/0wqPjfoolXN//o/LZtZ1h78cZsJw==",
+			"version": "0.0.1-next.14",
+			"resolved": "https://registry.npmjs.org/@twin.org/background-task-connector-entity-storage/-/background-task-connector-entity-storage-0.0.1-next.14.tgz",
+			"integrity": "sha512-OYsza6tr6PuttyVZ6/HTjiqe63Xj66mz/mGPAUcVeHIu70MBwwA2HEAtnMvq+2lAhbjxNqsgvDdvx1K9mDnCag==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@twin.org/background-task-models": "0.0.1-next.13",
+				"@twin.org/background-task-models": "0.0.1-next.14",
 				"@twin.org/core": "next",
 				"@twin.org/crypto": "next",
 				"@twin.org/engine-models": "next",
@@ -2593,9 +2573,9 @@
 			}
 		},
 		"node_modules/@twin.org/background-task-models": {
-			"version": "0.0.1-next.13",
-			"resolved": "https://registry.npmjs.org/@twin.org/background-task-models/-/background-task-models-0.0.1-next.13.tgz",
-			"integrity": "sha512-6zGDcmgQQnt2Kgc8FELkHZ+vhsNHdpyfvikiqlX7aK7sYf57TyLqoItF+Rb3d8vgu2cF3Ew1xovwWxs534Z13A==",
+			"version": "0.0.1-next.14",
+			"resolved": "https://registry.npmjs.org/@twin.org/background-task-models/-/background-task-models-0.0.1-next.14.tgz",
+			"integrity": "sha512-g+CrNm73mNnx3J2f0LrPo9wVQ/qD2uMBO2WAHKnhpctfzVPjUYVTDrDVR13485E1BM8fiOfD6Z9s3yh77/I3Ew==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -2697,16 +2677,16 @@
 			}
 		},
 		"node_modules/@twin.org/engine-core": {
-			"version": "0.0.1-next.66",
-			"resolved": "https://registry.npmjs.org/@twin.org/engine-core/-/engine-core-0.0.1-next.66.tgz",
-			"integrity": "sha512-2ND+2l9UmKdbW3T94ATCybm8YJBMl0y6RKoYXsWC68qnpux4pmYdZ/12eU4bmr9D7Ix7mQGkpEL4xDBIo7K95Q==",
+			"version": "0.0.1-next.67",
+			"resolved": "https://registry.npmjs.org/@twin.org/engine-core/-/engine-core-0.0.1-next.67.tgz",
+			"integrity": "sha512-hLL0cw2mKT8bhKB1k20jR2ks9Th+OJL2KZHpmuPkgk/pWVJxz3YxVxKf7ok25Tunqq/plGpRjwtvadRQCOSmAw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@twin.org/core": "next",
 				"@twin.org/crypto": "next",
 				"@twin.org/data-core": "next",
-				"@twin.org/engine-models": "0.0.1-next.66",
+				"@twin.org/engine-models": "0.0.1-next.67",
 				"@twin.org/entity": "next",
 				"@twin.org/logging-connector-console": "next",
 				"@twin.org/logging-models": "next",
@@ -2718,9 +2698,9 @@
 			}
 		},
 		"node_modules/@twin.org/engine-models": {
-			"version": "0.0.1-next.66",
-			"resolved": "https://registry.npmjs.org/@twin.org/engine-models/-/engine-models-0.0.1-next.66.tgz",
-			"integrity": "sha512-+Z/VmTPVt2QIMEz0Lt4sNbNVZaxgVpcPbyxGwlRAxUfFwFGhID0crgPP1mMfQ7yx+2Kw52fSDn6Q9E8Pel/Ytg==",
+			"version": "0.0.1-next.67",
+			"resolved": "https://registry.npmjs.org/@twin.org/engine-models/-/engine-models-0.0.1-next.67.tgz",
+			"integrity": "sha512-quR5Rwf/fqcrkD1IFyjGPVZcr0/DjK8ShYmzxnbBv03UAf3RTRfvmpY+SitTpTX2JN70JmWLc94AcJwsPrmQdQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -2746,15 +2726,15 @@
 			}
 		},
 		"node_modules/@twin.org/entity-storage-connector-memory": {
-			"version": "0.0.1-next.27",
-			"resolved": "https://registry.npmjs.org/@twin.org/entity-storage-connector-memory/-/entity-storage-connector-memory-0.0.1-next.27.tgz",
-			"integrity": "sha512-qb5UpAkZv5n4HsHXAPMz60d0HM/e0uxAVbmEef1NkwwYXNq4Yv3RD6L6CBTefYG6cQwi2uRwFfcHCLLGhlSAiA==",
+			"version": "0.0.1-next.28",
+			"resolved": "https://registry.npmjs.org/@twin.org/entity-storage-connector-memory/-/entity-storage-connector-memory-0.0.1-next.28.tgz",
+			"integrity": "sha512-QwgCfXzVa9LAsBut/znoJnvj8XKHonhuPZa2zU/jcMevQEb134T6bI5I8+atiN6Sccbqxcgli1ZTV+0YsHhddA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@twin.org/core": "next",
 				"@twin.org/entity": "next",
-				"@twin.org/entity-storage-models": "0.0.1-next.27",
+				"@twin.org/entity-storage-models": "0.0.1-next.28",
 				"@twin.org/nameof": "next"
 			},
 			"engines": {
@@ -2762,9 +2742,9 @@
 			}
 		},
 		"node_modules/@twin.org/entity-storage-models": {
-			"version": "0.0.1-next.27",
-			"resolved": "https://registry.npmjs.org/@twin.org/entity-storage-models/-/entity-storage-models-0.0.1-next.27.tgz",
-			"integrity": "sha512-E5wToAtB6j0Esbgdb4SgjYtp3PaORrHqimOvtKnKIgfvyWgMskCoQlHSr7KVjblWSPmnteTJs1fY08w0Xnwyww==",
+			"version": "0.0.1-next.28",
+			"resolved": "https://registry.npmjs.org/@twin.org/entity-storage-models/-/entity-storage-models-0.0.1-next.28.tgz",
+			"integrity": "sha512-PzcUElO0hV1jXtwqm/q7zjlgZHix7APt5RuICd8Z1x+6NWbGu5YfcP46aOXWN/LAi8nQLu2a2P3Ir+g5COqtyg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@twin.org/core": "next",
@@ -2789,9 +2769,9 @@
 			}
 		},
 		"node_modules/@twin.org/identity-connector-entity-storage": {
-			"version": "0.0.1-next.40",
-			"resolved": "https://registry.npmjs.org/@twin.org/identity-connector-entity-storage/-/identity-connector-entity-storage-0.0.1-next.40.tgz",
-			"integrity": "sha512-0nUEHZEEuctI+lXX1exlmuPAnGhuEOIjfXuGxqbjNC3B5hecwE3VzPDArdnQfKuxKC0jmtTS6QSqcH5SSkMv0w==",
+			"version": "0.0.1-next.41",
+			"resolved": "https://registry.npmjs.org/@twin.org/identity-connector-entity-storage/-/identity-connector-entity-storage-0.0.1-next.41.tgz",
+			"integrity": "sha512-Ee0T8hLNJDuq3tJyoS16rheooW6n9Wtft6xc1lbVf2ETVtalaFuK//+5OgYAb8JFTcKmZ1CMFryB+te6QkcMuA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -2800,7 +2780,7 @@
 				"@twin.org/data-core": "next",
 				"@twin.org/data-json-ld": "next",
 				"@twin.org/entity": "next",
-				"@twin.org/identity-models": "0.0.1-next.40",
+				"@twin.org/identity-models": "0.0.1-next.41",
 				"@twin.org/nameof": "next",
 				"@twin.org/standards-w3c-did": "next",
 				"@twin.org/vault-models": "next",
@@ -2811,9 +2791,9 @@
 			}
 		},
 		"node_modules/@twin.org/identity-models": {
-			"version": "0.0.1-next.40",
-			"resolved": "https://registry.npmjs.org/@twin.org/identity-models/-/identity-models-0.0.1-next.40.tgz",
-			"integrity": "sha512-0pjhvhMG+nX3YYIVIzv2FsIpsNz12HYue60ksVCxL8zOJrDEA1hZjm8UwGfGZVYLe+LhjS1a7v/mdv62SiWXAg==",
+			"version": "0.0.1-next.41",
+			"resolved": "https://registry.npmjs.org/@twin.org/identity-models/-/identity-models-0.0.1-next.41.tgz",
+			"integrity": "sha512-XIPm3LPd/uFgrBwi+1z5EiDagPvjRZ3BrGy09dTiH74jKIjE15FWs8Qe0h/S2KnFhDL7qa+f4q8OGkCh2HA5gg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -2958,6 +2938,20 @@
 			},
 			"engines": {
 				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@twin.org/nameof-transformer/node_modules/typescript": {
+			"version": "5.8.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+			"integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/@twin.org/nameof-vitest-plugin": {
@@ -3157,9 +3151,9 @@
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+			"integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3214,13 +3208,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "22.13.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.14.tgz",
-			"integrity": "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==",
+			"version": "22.14.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.0.tgz",
+			"integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~6.20.0"
+				"undici-types": "~6.21.0"
 			}
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -3711,10 +3705,20 @@
 				}
 			}
 		},
+		"node_modules/@vitest/mocker/node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "3.0.9",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.9.tgz",
-			"integrity": "sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.1.tgz",
+			"integrity": "sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3930,6 +3934,19 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/anymatch/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/are-docs-informative": {
@@ -4351,9 +4368,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001707",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
-			"integrity": "sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==",
+			"version": "1.0.30001713",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz",
+			"integrity": "sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -5919,9 +5936,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.128",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.128.tgz",
-			"integrity": "sha512-bo1A4HH/NS522Ws0QNFIzyPcyUUNV/yyy70Ho1xqfGYzPUme2F/xr4tlEOuM6/A538U1vDA7a4XfCd1CKRegKQ==",
+			"version": "1.5.136",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.136.tgz",
+			"integrity": "sha512-kL4+wUTD7RSA5FHx5YwWtjDnEEkIIikFgWHR4P6fqjw1PPLlqYkxeOb++wAauAssat0YClCy8Y3C5SxgSkjibQ==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -6158,9 +6175,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.25.1",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.1.tgz",
-			"integrity": "sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==",
+			"version": "0.25.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.2.tgz",
+			"integrity": "sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -6171,31 +6188,31 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.25.1",
-				"@esbuild/android-arm": "0.25.1",
-				"@esbuild/android-arm64": "0.25.1",
-				"@esbuild/android-x64": "0.25.1",
-				"@esbuild/darwin-arm64": "0.25.1",
-				"@esbuild/darwin-x64": "0.25.1",
-				"@esbuild/freebsd-arm64": "0.25.1",
-				"@esbuild/freebsd-x64": "0.25.1",
-				"@esbuild/linux-arm": "0.25.1",
-				"@esbuild/linux-arm64": "0.25.1",
-				"@esbuild/linux-ia32": "0.25.1",
-				"@esbuild/linux-loong64": "0.25.1",
-				"@esbuild/linux-mips64el": "0.25.1",
-				"@esbuild/linux-ppc64": "0.25.1",
-				"@esbuild/linux-riscv64": "0.25.1",
-				"@esbuild/linux-s390x": "0.25.1",
-				"@esbuild/linux-x64": "0.25.1",
-				"@esbuild/netbsd-arm64": "0.25.1",
-				"@esbuild/netbsd-x64": "0.25.1",
-				"@esbuild/openbsd-arm64": "0.25.1",
-				"@esbuild/openbsd-x64": "0.25.1",
-				"@esbuild/sunos-x64": "0.25.1",
-				"@esbuild/win32-arm64": "0.25.1",
-				"@esbuild/win32-ia32": "0.25.1",
-				"@esbuild/win32-x64": "0.25.1"
+				"@esbuild/aix-ppc64": "0.25.2",
+				"@esbuild/android-arm": "0.25.2",
+				"@esbuild/android-arm64": "0.25.2",
+				"@esbuild/android-x64": "0.25.2",
+				"@esbuild/darwin-arm64": "0.25.2",
+				"@esbuild/darwin-x64": "0.25.2",
+				"@esbuild/freebsd-arm64": "0.25.2",
+				"@esbuild/freebsd-x64": "0.25.2",
+				"@esbuild/linux-arm": "0.25.2",
+				"@esbuild/linux-arm64": "0.25.2",
+				"@esbuild/linux-ia32": "0.25.2",
+				"@esbuild/linux-loong64": "0.25.2",
+				"@esbuild/linux-mips64el": "0.25.2",
+				"@esbuild/linux-ppc64": "0.25.2",
+				"@esbuild/linux-riscv64": "0.25.2",
+				"@esbuild/linux-s390x": "0.25.2",
+				"@esbuild/linux-x64": "0.25.2",
+				"@esbuild/netbsd-arm64": "0.25.2",
+				"@esbuild/netbsd-x64": "0.25.2",
+				"@esbuild/openbsd-arm64": "0.25.2",
+				"@esbuild/openbsd-x64": "0.25.2",
+				"@esbuild/sunos-x64": "0.25.2",
+				"@esbuild/win32-arm64": "0.25.2",
+				"@esbuild/win32-ia32": "0.25.2",
+				"@esbuild/win32-x64": "0.25.2"
 			}
 		},
 		"node_modules/escalade": {
@@ -6973,14 +6990,11 @@
 			}
 		},
 		"node_modules/estree-walker": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "^1.0.0"
-			}
+			"license": "MIT"
 		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
@@ -7002,9 +7016,9 @@
 			}
 		},
 		"node_modules/expect-type": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.0.tgz",
-			"integrity": "sha512-80F22aiJ3GLyVnS/B3HzgR6RelZVumzj9jkL0Rhz4h0xYbNW9PjlQz5h3J/SShErbXBc295vseR4/MIbVmUbeA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
+			"integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -7102,6 +7116,21 @@
 			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
+			}
+		},
+		"node_modules/fdir": {
+			"version": "6.4.3",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
+			"integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/fetch-blob": {
@@ -8796,9 +8825,9 @@
 			}
 		},
 		"node_modules/katex": {
-			"version": "0.16.21",
-			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.21.tgz",
-			"integrity": "sha512-XvqR7FgOHtWupfMiigNzmh+MgUVmDGU2kXZm899ZkPfcuoPuFxyHmXsgATDpFZDAXCI8tvinaVcDo8PIIJSo4A==",
+			"version": "0.16.22",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.22.tgz",
+			"integrity": "sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==",
 			"dev": true,
 			"funding": [
 				"https://opencollective.com/katex",
@@ -9829,6 +9858,19 @@
 				"node": ">=8.6"
 			}
 		},
+		"node_modules/micromatch/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -10511,13 +10553,13 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=8.6"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
@@ -10832,6 +10874,19 @@
 			},
 			"engines": {
 				"node": ">=8.10.0"
+			}
+		},
+		"node_modules/readdirp/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/redent": {
@@ -11194,6 +11249,13 @@
 				"@rollup/rollup-win32-x64-msvc": "4.34.9",
 				"fsevents": "~2.3.2"
 			}
+		},
+		"node_modules/rollup/node_modules/@types/estree": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/run-con": {
 			"version": "1.3.2",
@@ -11717,9 +11779,9 @@
 			"license": "MIT"
 		},
 		"node_modules/std-env": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.1.tgz",
-			"integrity": "sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA==",
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+			"integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -12143,34 +12205,6 @@
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
-		"node_modules/tinyglobby/node_modules/fdir": {
-			"version": "6.4.3",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-			"integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/tinypool": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
@@ -12566,9 +12600,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.8.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-			"integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+			"version": "5.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -12639,9 +12673,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "6.20.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-			"integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -12788,9 +12822,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
-			"integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
+			"version": "6.2.6",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.2.6.tgz",
+			"integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13311,9 +13345,9 @@
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-			"integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+			"integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -13420,6 +13454,20 @@
 				"node": ">=20.0.0"
 			}
 		},
+		"packages/auditable-item-graph-models/node_modules/typescript": {
+			"version": "5.8.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+			"integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
 		"packages/auditable-item-graph-rest-client": {
 			"name": "@twin.org/auditable-item-graph-rest-client",
 			"version": "0.0.1-next.36",
@@ -13451,6 +13499,20 @@
 			},
 			"engines": {
 				"node": ">=20.0.0"
+			}
+		},
+		"packages/auditable-item-graph-rest-client/node_modules/typescript": {
+			"version": "5.8.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+			"integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
 			}
 		},
 		"packages/auditable-item-graph-service": {
@@ -13510,6 +13572,27 @@
 			"dependencies": {
 				"undici-types": "~6.20.0"
 			}
+		},
+		"packages/auditable-item-graph-service/node_modules/typescript": {
+			"version": "5.8.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+			"integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"packages/auditable-item-graph-service/node_modules/undici-types": {
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+			"integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+			"dev": true,
+			"license": "MIT"
 		}
 	}
 }

--- a/packages/auditable-item-graph-service/tests/auditableItemGraphService.spec.ts
+++ b/packages/auditable-item-graph-service/tests/auditableItemGraphService.spec.ts
@@ -176,9 +176,10 @@ describe("AuditableItemGraphService", () => {
 		]);
 
 		const immutableStore = verifiableStorage.getStore();
-		expect(immutableStore).toMatchObject([
+		expect(immutableStore).toEqual([
 			{
 				id: "0505050505050505050505050505050505050505050505050505050505050505",
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMiLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6M1ZjdWgyQlA5U2hDNFVFSjN5UlpnY1RKNmdtUnR5ZERyaDZBbVkxekVjaVFxRVdUdlhmQlpOeHhqVHpkSmpUNDRjbW45VkRXYkJIcXhGc1g5ZmpzZlh6SyIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDplbnRpdHktc3RvcmFnZToweDYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjMjaW1tdXRhYmxlLXByb29mLWFzc2VydGlvbiJ9LCJwcm9vZk9iamVjdEhhc2giOiJzaGEyNTY6VlBzSHFnaWdFSVB0QlptWEtzQ2VnU2Q4K25EaWxRcThnbzkrTGtkWWR1Yz0iLCJwcm9vZk9iamVjdElkIjoiYWlnOjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDE6Y2hhbmdlc2V0OjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIifQ==",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			}
@@ -187,7 +188,7 @@ describe("AuditableItemGraphService", () => {
 		const immutableProof = ObjectHelper.fromBytes<IImmutableProof>(
 			Converter.base64ToBytes(immutableStore[0].data)
 		);
-		expect(immutableProof).toMatchObject({
+		expect(immutableProof).toEqual({
 			"@context": [
 				"https://schema.twindev.org/immutable-proof/",
 				"https://schema.twindev.org/common/",
@@ -198,9 +199,12 @@ describe("AuditableItemGraphService", () => {
 			proofObjectHash: "sha256:VPsHqgigEIPtBZmXKsCegSd8+nDilQq8go9+LkdYduc=",
 			proofObjectId:
 				"aig:0101010101010101010101010101010101010101010101010101010101010101:changeset:0202020202020202020202020202020202020202020202020202020202020202",
+			nodeIdentity:
+				"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363",
 			userIdentity:
 				"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 			proof: {
+				created: "2024-08-22T11:56:56.272Z",
 				type: "DataIntegrityProof",
 				cryptosuite: "eddsa-jcs-2022",
 				proofPurpose: "assertionMethod",
@@ -274,9 +278,10 @@ describe("AuditableItemGraphService", () => {
 		await waitForProofGeneration();
 
 		const immutableStore = verifiableStorage.getStore();
-		expect(immutableStore).toMatchObject([
+		expect(immutableStore).toEqual([
 			{
 				id: "0505050505050505050505050505050505050505050505050505050505050505",
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMiLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6MzZoMmtRdThFWHpNWVNXdGtaZ3ZjVmpZZXVSVG03OVlyOWRQelZHOGpBU05jakZYUWhlVGU2R1RHYmdvYTNxUGhuZVlyOUdCWGhkQXJqcEY1ZUM3dnB0VSIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDplbnRpdHktc3RvcmFnZToweDYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjMjaW1tdXRhYmxlLXByb29mLWFzc2VydGlvbiJ9LCJwcm9vZk9iamVjdEhhc2giOiJzaGEyNTY6aktVdkhIWjlrcE5DNXVmZ1lwRFY1ZjF0amt6L0pEbExDbW91L3g5OVhQbz0iLCJwcm9vZk9iamVjdElkIjoiYWlnOjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDE6Y2hhbmdlc2V0OjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIifQ==",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			}
@@ -285,7 +290,7 @@ describe("AuditableItemGraphService", () => {
 		const immutableProof = ObjectHelper.fromBytes<IImmutableProof>(
 			Converter.base64ToBytes(immutableStore[0].data)
 		);
-		expect(immutableProof).toMatchObject({
+		expect(immutableProof).toEqual({
 			"@context": [
 				"https://schema.twindev.org/immutable-proof/",
 				"https://schema.twindev.org/common/",
@@ -296,10 +301,13 @@ describe("AuditableItemGraphService", () => {
 			proofObjectHash: "sha256:jKUvHHZ9kpNC5ufgYpDV5f1tjkz/JDlLCmou/x99XPo=",
 			proofObjectId:
 				"aig:0101010101010101010101010101010101010101010101010101010101010101:changeset:0202020202020202020202020202020202020202020202020202020202020202",
+			nodeIdentity:
+				"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363",
 			userIdentity:
 				"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 			proof: {
 				type: "DataIntegrityProof",
+				created: "2024-08-22T11:56:56.272Z",
 				cryptosuite: "eddsa-jcs-2022",
 				proofPurpose: "assertionMethod",
 				proofValue:
@@ -392,9 +400,10 @@ describe("AuditableItemGraphService", () => {
 		await waitForProofGeneration();
 
 		const immutableStore = verifiableStorage.getStore();
-		expect(immutableStore).toMatchObject([
+		expect(immutableStore).toEqual([
 			{
 				id: "0505050505050505050505050505050505050505050505050505050505050505",
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMiLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6ZnBLZEZxV1JwczhadHJKTFpERjhBY2dWdkM3dkhVdmsyQTVoVUpuMXBhMlVYMlJhRlVHOEd2SkoydUVkcnBCcXdNRHVld2ZvY3FHTmJvbTl3MnhmUnJBIiwidmVyaWZpY2F0aW9uTWV0aG9kIjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MyNpbW11dGFibGUtcHJvb2YtYXNzZXJ0aW9uIn0sInByb29mT2JqZWN0SGFzaCI6InNoYTI1NjpSc2FKMlJ6OUNDaysrbTVEVk1ldStoajNubHc0MTYwSGpIbHlTTnpRb3JvPSIsInByb29mT2JqZWN0SWQiOiJhaWc6MDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTpjaGFuZ2VzZXQ6MDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMiJ9",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			}
@@ -403,7 +412,7 @@ describe("AuditableItemGraphService", () => {
 		const immutableProof = ObjectHelper.fromBytes<IImmutableProof>(
 			Converter.base64ToBytes(immutableStore[0].data)
 		);
-		expect(immutableProof).toMatchObject({
+		expect(immutableProof).toEqual({
 			"@context": [
 				"https://schema.twindev.org/immutable-proof/",
 				"https://schema.twindev.org/common/",
@@ -414,10 +423,13 @@ describe("AuditableItemGraphService", () => {
 			proofObjectHash: "sha256:RsaJ2Rz9CCk++m5DVMeu+hj3nlw4160HjHlySNzQoro=",
 			proofObjectId:
 				"aig:0101010101010101010101010101010101010101010101010101010101010101:changeset:0202020202020202020202020202020202020202020202020202020202020202",
+			nodeIdentity:
+				"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363",
 			userIdentity:
 				"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 			proof: {
 				type: "DataIntegrityProof",
+				created: "2024-08-22T11:56:56.272Z",
 				cryptosuite: "eddsa-jcs-2022",
 				proofPurpose: "assertionMethod",
 				proofValue:
@@ -627,8 +639,10 @@ describe("AuditableItemGraphService", () => {
 		await waitForProofGeneration();
 
 		const immutableStore = verifiableStorage.getStore();
-		expect(immutableStore).toMatchObject([
+		expect(immutableStore).toEqual([
 			{
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMiLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6OVBqc29BZWJLb011WThkenpyaWdiZ3V4TlZpaThxbVhtMkZCbTlYSktialFxRXJTR3FkTWhmUmk2YWc5OFIzUjJyRU1mWHVGMlkzdmhBajR1ZWcyazRRIiwidmVyaWZpY2F0aW9uTWV0aG9kIjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MyNpbW11dGFibGUtcHJvb2YtYXNzZXJ0aW9uIn0sInByb29mT2JqZWN0SGFzaCI6InNoYTI1NjpnenFFYWJ5ZXYrSEJ3RFR4NGxEc3ZkdHNUbzNmcjI5WndxU3dwV2ZSMWxnPSIsInByb29mT2JqZWN0SWQiOiJhaWc6MDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTpjaGFuZ2VzZXQ6MDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMiJ9",
+				id: "0505050505050505050505050505050505050505050505050505050505050505",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			}
@@ -637,7 +651,7 @@ describe("AuditableItemGraphService", () => {
 		const immutableProof = ObjectHelper.fromBytes<IImmutableProof>(
 			Converter.base64ToBytes(immutableStore[0].data)
 		);
-		expect(immutableProof).toMatchObject({
+		expect(immutableProof).toEqual({
 			"@context": [
 				"https://schema.twindev.org/immutable-proof/",
 				"https://schema.twindev.org/common/",
@@ -648,10 +662,13 @@ describe("AuditableItemGraphService", () => {
 			proofObjectHash: "sha256:gzqEabyev+HBwDTx4lDsvdtsTo3fr29ZwqSwpWfR1lg=",
 			proofObjectId:
 				"aig:0101010101010101010101010101010101010101010101010101010101010101:changeset:0202020202020202020202020202020202020202020202020202020202020202",
+			nodeIdentity:
+				"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363",
 			userIdentity:
 				"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 			proof: {
 				type: "DataIntegrityProof",
+				created: "2024-08-22T11:56:56.272Z",
 				cryptosuite: "eddsa-jcs-2022",
 				proofPurpose: "assertionMethod",
 				proofValue:
@@ -806,18 +823,19 @@ describe("AuditableItemGraphService", () => {
 		await waitForProofGeneration();
 
 		const immutableStore = verifiableStorage.getStore();
-		expect(immutableStore).toMatchObject([
+		expect(immutableStore).toEqual([
 			{
 				id: "0505050505050505050505050505050505050505050505050505050505050505",
 				controller:
-					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
+					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363",
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMiLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6M0IzaWJhWHNkWWtZOUFUaVZGNkFGQnRWS3ZWM3pLZGo0ZHB3YUhwMWgzWGhxakNrMnBVRmpUTDRSc0ZlR0dCa0hCZ1p1ZFhhWWtGZmU1aDNlNVY0a21URSIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDplbnRpdHktc3RvcmFnZToweDYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjMjaW1tdXRhYmxlLXByb29mLWFzc2VydGlvbiJ9LCJwcm9vZk9iamVjdEhhc2giOiJzaGEyNTY6cWV4SEZPdnRxK083WDlwLzA3M1I0TmFjNmw4RWZIdVpMUTF6RGd0L1dRQT0iLCJwcm9vZk9iamVjdElkIjoiYWlnOjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDE6Y2hhbmdlc2V0OjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIifQ=="
 			}
 		]);
 
 		const immutableProof = ObjectHelper.fromBytes<IImmutableProof>(
 			Converter.base64ToBytes(immutableStore[0].data)
 		);
-		expect(immutableProof).toMatchObject({
+		expect(immutableProof).toEqual({
 			"@context": [
 				"https://schema.twindev.org/immutable-proof/",
 				"https://schema.twindev.org/common/",
@@ -828,10 +846,13 @@ describe("AuditableItemGraphService", () => {
 			proofObjectHash: "sha256:qexHFOvtq+O7X9p/073R4Nac6l8EfHuZLQ1zDgt/WQA=",
 			proofObjectId:
 				"aig:0101010101010101010101010101010101010101010101010101010101010101:changeset:0202020202020202020202020202020202020202020202020202020202020202",
+			nodeIdentity:
+				"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363",
 			userIdentity:
 				"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 			proof: {
 				type: "DataIntegrityProof",
+				created: "2024-08-22T11:56:56.272Z",
 				cryptosuite: "eddsa-jcs-2022",
 				proofPurpose: "assertionMethod",
 				proofValue:
@@ -1047,7 +1068,7 @@ describe("AuditableItemGraphService", () => {
 			verifySignatureDepth: VerifyDepth.All
 		});
 
-		expect(result).toMatchObject({
+		expect(result).toEqual({
 			"@context": [
 				"https://schema.twindev.org/aig/",
 				"https://schema.twindev.org/common/",
@@ -1127,7 +1148,10 @@ describe("AuditableItemGraphService", () => {
 						verified: true
 					},
 					userIdentity:
-						"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858"
+						"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
+					id: "0606060606060606060606060606060606060606060606060606060606060606",
+					proofId:
+						"immutable-proof:0707070707070707070707070707070707070707070707070707070707070707"
 				}
 			],
 			nodeIdentity:
@@ -1143,7 +1167,7 @@ describe("AuditableItemGraphService", () => {
 		});
 
 		const changesetStore = changesetStorage.getStore();
-		expect(changesetStore).toMatchObject([
+		expect(changesetStore).toEqual([
 			{
 				id: "0202020202020202020202020202020202020202020202020202020202020202",
 				vertexId: "0101010101010101010101010101010101010101010101010101010101010101",
@@ -1176,6 +1200,7 @@ describe("AuditableItemGraphService", () => {
 			{
 				vertexId: "0101010101010101010101010101010101010101010101010101010101010101",
 				dateCreated: "2024-08-22T11:56:56.272Z",
+				id: "0606060606060606060606060606060606060606060606060606060606060606",
 				userIdentity:
 					"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 				patches: [
@@ -1185,17 +1210,22 @@ describe("AuditableItemGraphService", () => {
 						path: "/aliases/-",
 						value: { id: "foo321", dateCreated: "2024-08-22T11:56:56.272Z" }
 					}
-				]
+				],
+				proofId: "immutable-proof:0707070707070707070707070707070707070707070707070707070707070707"
 			}
 		]);
 
 		const immutableStore = verifiableStorage.getStore();
-		expect(immutableStore).toMatchObject([
+		expect(immutableStore).toEqual([
 			{
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMiLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6M0IzaWJhWHNkWWtZOUFUaVZGNkFGQnRWS3ZWM3pLZGo0ZHB3YUhwMWgzWGhxakNrMnBVRmpUTDRSc0ZlR0dCa0hCZ1p1ZFhhWWtGZmU1aDNlNVY0a21URSIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDplbnRpdHktc3RvcmFnZToweDYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjMjaW1tdXRhYmxlLXByb29mLWFzc2VydGlvbiJ9LCJwcm9vZk9iamVjdEhhc2giOiJzaGEyNTY6cWV4SEZPdnRxK083WDlwLzA3M1I0TmFjNmw4RWZIdVpMUTF6RGd0L1dRQT0iLCJwcm9vZk9iamVjdElkIjoiYWlnOjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDE6Y2hhbmdlc2V0OjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIifQ==",
+				id: "0505050505050505050505050505050505050505050505050505050505050505",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			},
 			{
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDciLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6NU1ld0N3OXYxOUdFNXdSb0pMTWZjSGhpU21NdVA3TDdYS0E5TWh3N3ZFZkpuQlZUY3F6RUZGV3l3a1dUV3B4SmpreFdFd3hFY0p6TlRhcUh5bUh0U2JVSCIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDplbnRpdHktc3RvcmFnZToweDYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjMjaW1tdXRhYmxlLXByb29mLWFzc2VydGlvbiJ9LCJwcm9vZk9iamVjdEhhc2giOiJzaGEyNTY6cTdoTHNUY2NzbFBJSDlxMFFZaDZjZlNhcHFsNUM3NUZwNThRODI2Y2cvWT0iLCJwcm9vZk9iamVjdElkIjoiYWlnOjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDE6Y2hhbmdlc2V0OjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYifQ==",
+				id: "0909090909090909090909090909090909090909090909090909090909090909",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			}
@@ -1204,7 +1234,7 @@ describe("AuditableItemGraphService", () => {
 		let immutableProof = ObjectHelper.fromBytes<IImmutableProof>(
 			Converter.base64ToBytes(immutableStore[0].data)
 		);
-		expect(immutableProof).toMatchObject({
+		expect(immutableProof).toEqual({
 			"@context": [
 				"https://schema.twindev.org/immutable-proof/",
 				"https://schema.twindev.org/common/",
@@ -1215,10 +1245,13 @@ describe("AuditableItemGraphService", () => {
 			proofObjectHash: "sha256:qexHFOvtq+O7X9p/073R4Nac6l8EfHuZLQ1zDgt/WQA=",
 			proofObjectId:
 				"aig:0101010101010101010101010101010101010101010101010101010101010101:changeset:0202020202020202020202020202020202020202020202020202020202020202",
+			nodeIdentity:
+				"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363",
 			userIdentity:
 				"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 			proof: {
 				type: "DataIntegrityProof",
+				created: "2024-08-22T11:56:56.272Z",
 				cryptosuite: "eddsa-jcs-2022",
 				proofPurpose: "assertionMethod",
 				proofValue:
@@ -1231,25 +1264,31 @@ describe("AuditableItemGraphService", () => {
 		immutableProof = ObjectHelper.fromBytes<IImmutableProof>(
 			Converter.base64ToBytes(immutableStore[1].data)
 		);
-		expect(immutableProof).toMatchObject({
+		expect(immutableProof).toEqual({
 			"@context": [
 				"https://schema.twindev.org/immutable-proof/",
 				"https://schema.twindev.org/common/",
 				"https://www.w3.org/ns/credentials/v2"
 			],
 			type: "ImmutableProof",
-			proofObjectHash: "sha256:0jEEy9KV4/E3OpdfGI5o0PvXG4cijtMTex2uGPyL6bg=",
+			id: "0707070707070707070707070707070707070707070707070707070707070707",
+			nodeIdentity:
+				"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363",
+			proofObjectHash: "sha256:q7hLsTccslPIH9q0QYh6cfSapql5C75Fp58Q826cg/Y=",
 			userIdentity:
 				"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 			proof: {
 				type: "DataIntegrityProof",
+				created: "2024-08-22T11:56:56.272Z",
 				cryptosuite: "eddsa-jcs-2022",
 				proofPurpose: "assertionMethod",
 				proofValue:
-					"z4poHio4SKuVx8PT49proW5tUaMHgAX7eebwszxVqVKkn6MWVzz9FtZYFru8wGYbUNuNUJ6Z2s2qC4mjPHdJ7Wag4",
+					"z5MewCw9v19GE5wRoJLMfcHhiSmMuP7L7XKA9Mhw7vEfJnBVTcqzEFFWywkWTWpxJjkxWEwxEcJzNTaqHymHtSbUH",
 				verificationMethod:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363#immutable-proof-assertion"
-			}
+			},
+			proofObjectId:
+				"aig:0101010101010101010101010101010101010101010101010101010101010101:changeset:0606060606060606060606060606060606060606060606060606060606060606"
 		});
 	});
 
@@ -1307,7 +1346,7 @@ describe("AuditableItemGraphService", () => {
 			verifySignatureDepth: VerifyDepth.All
 		});
 
-		expect(result).toMatchObject({
+		expect(result).toEqual({
 			"@context": [
 				"https://schema.twindev.org/aig/",
 				"https://schema.twindev.org/common/",
@@ -1358,6 +1397,7 @@ describe("AuditableItemGraphService", () => {
 				},
 				{
 					type: "AuditableItemGraphChangeset",
+					id: "0606060606060606060606060606060606060606060606060606060606060606",
 					dateCreated: "2024-08-22T11:56:56.272Z",
 					patches: [
 						{
@@ -1368,6 +1408,8 @@ describe("AuditableItemGraphService", () => {
 						}
 					],
 					verification: { type: "ImmutableProofVerification", verified: true },
+					proofId:
+						"immutable-proof:0707070707070707070707070707070707070707070707070707070707070707",
 					userIdentity:
 						"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858"
 				}
@@ -1386,7 +1428,7 @@ describe("AuditableItemGraphService", () => {
 
 		const changesetStore = changesetStorage.getStore();
 
-		expect(changesetStore).toMatchObject([
+		expect(changesetStore).toEqual([
 			{
 				id: "0202020202020202020202020202020202020202020202020202020202020202",
 				vertexId: "0101010101010101010101010101010101010101010101010101010101010101",
@@ -1417,10 +1459,12 @@ describe("AuditableItemGraphService", () => {
 				proofId: "immutable-proof:0303030303030303030303030303030303030303030303030303030303030303"
 			},
 			{
+				id: "0606060606060606060606060606060606060606060606060606060606060606",
 				vertexId: "0101010101010101010101010101010101010101010101010101010101010101",
 				dateCreated: "2024-08-22T11:56:56.272Z",
 				userIdentity:
 					"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
+				proofId: "immutable-proof:0707070707070707070707070707070707070707070707070707070707070707",
 				patches: [
 					{
 						op: "replace",
@@ -1432,12 +1476,16 @@ describe("AuditableItemGraphService", () => {
 		]);
 
 		const immutableStore = verifiableStorage.getStore();
-		expect(immutableStore).toMatchObject([
+		expect(immutableStore).toEqual([
 			{
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMiLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6M0IzaWJhWHNkWWtZOUFUaVZGNkFGQnRWS3ZWM3pLZGo0ZHB3YUhwMWgzWGhxakNrMnBVRmpUTDRSc0ZlR0dCa0hCZ1p1ZFhhWWtGZmU1aDNlNVY0a21URSIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDplbnRpdHktc3RvcmFnZToweDYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjMjaW1tdXRhYmxlLXByb29mLWFzc2VydGlvbiJ9LCJwcm9vZk9iamVjdEhhc2giOiJzaGEyNTY6cWV4SEZPdnRxK083WDlwLzA3M1I0TmFjNmw4RWZIdVpMUTF6RGd0L1dRQT0iLCJwcm9vZk9iamVjdElkIjoiYWlnOjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDE6Y2hhbmdlc2V0OjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIifQ==",
+				id: "0505050505050505050505050505050505050505050505050505050505050505",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			},
 			{
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDciLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6NVhKNUtKQ3NicU1YYUszODc5em9Zc2pDSGRtWGtBRnhTOEhjcXRZY1dDa0IySk16UXdFTlFjS0RuYWtCcm51cG5xOXhURG82MlMxVjRmUzJ3TW5RYjc2byIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDplbnRpdHktc3RvcmFnZToweDYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjMjaW1tdXRhYmxlLXByb29mLWFzc2VydGlvbiJ9LCJwcm9vZk9iamVjdEhhc2giOiJzaGEyNTY6RndSTTlsdU90Zy9UZktjaXN0Z0NGcTlSaGxzZUM2RjBvb1ZRSFVSaDdQUT0iLCJwcm9vZk9iamVjdElkIjoiYWlnOjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDE6Y2hhbmdlc2V0OjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYifQ==",
+				id: "0909090909090909090909090909090909090909090909090909090909090909",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			}
@@ -1446,7 +1494,7 @@ describe("AuditableItemGraphService", () => {
 		let immutableProof = ObjectHelper.fromBytes<IImmutableProof>(
 			Converter.base64ToBytes(immutableStore[0].data)
 		);
-		expect(immutableProof).toMatchObject({
+		expect(immutableProof).toEqual({
 			"@context": [
 				"https://schema.twindev.org/immutable-proof/",
 				"https://schema.twindev.org/common/",
@@ -1457,10 +1505,13 @@ describe("AuditableItemGraphService", () => {
 			proofObjectHash: "sha256:qexHFOvtq+O7X9p/073R4Nac6l8EfHuZLQ1zDgt/WQA=",
 			proofObjectId:
 				"aig:0101010101010101010101010101010101010101010101010101010101010101:changeset:0202020202020202020202020202020202020202020202020202020202020202",
+			nodeIdentity:
+				"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363",
 			userIdentity:
 				"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 			proof: {
 				type: "DataIntegrityProof",
+				created: "2024-08-22T11:56:56.272Z",
 				cryptosuite: "eddsa-jcs-2022",
 				proofPurpose: "assertionMethod",
 				proofValue:
@@ -1473,22 +1524,28 @@ describe("AuditableItemGraphService", () => {
 		immutableProof = ObjectHelper.fromBytes<IImmutableProof>(
 			Converter.base64ToBytes(immutableStore[1].data)
 		);
-		expect(immutableProof).toMatchObject({
+		expect(immutableProof).toEqual({
 			"@context": [
 				"https://schema.twindev.org/immutable-proof/",
 				"https://schema.twindev.org/common/",
 				"https://www.w3.org/ns/credentials/v2"
 			],
 			type: "ImmutableProof",
-			proofObjectHash: "sha256:Ib+Ku9nMWbHkXoh1laoNmf0KPVxvJfpn/0fHsNhaLdA=",
+			proofObjectHash: "sha256:FwRM9luOtg/TfKcistgCFq9RhlseC6F0ooVQHURh7PQ=",
+			proofObjectId:
+				"aig:0101010101010101010101010101010101010101010101010101010101010101:changeset:0606060606060606060606060606060606060606060606060606060606060606",
+			id: "0707070707070707070707070707070707070707070707070707070707070707",
+			nodeIdentity:
+				"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363",
 			userIdentity:
 				"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 			proof: {
 				type: "DataIntegrityProof",
+				created: "2024-08-22T11:56:56.272Z",
 				cryptosuite: "eddsa-jcs-2022",
 				proofPurpose: "assertionMethod",
 				proofValue:
-					"z4gtm399Ntvq2MzSu7xQh2Y2Jr1z1cJaZahvpGV6U2ht7ngpPzYGtSuzjniKPvDcF529Z3fuubAZPkWeuoqLwyeSp",
+					"z5XJ5KJCsbqMXaK3879zoYsjCHdmXkAFxS8HcqtYcWCkB2JMzQwENQcKDnakBrnupnq9xTDo62S1V4fS2wMnQb76o",
 				verificationMethod:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363#immutable-proof-assertion"
 			}
@@ -1621,7 +1678,7 @@ describe("AuditableItemGraphService", () => {
 			verifySignatureDepth: VerifyDepth.All
 		});
 
-		expect(result).toMatchObject({
+		expect(result).toEqual({
 			"@context": [
 				"https://schema.twindev.org/aig/",
 				"https://schema.twindev.org/common/",
@@ -1701,6 +1758,7 @@ describe("AuditableItemGraphService", () => {
 				},
 				{
 					type: "AuditableItemGraphChangeset",
+					id: "0606060606060606060606060606060606060606060606060606060606060606",
 					dateCreated: "2024-08-22T11:56:56.272Z",
 					patches: [
 						{
@@ -1735,6 +1793,8 @@ describe("AuditableItemGraphService", () => {
 						}
 					],
 					verification: { type: "ImmutableProofVerification", verified: true },
+					proofId:
+						"immutable-proof:0707070707070707070707070707070707070707070707070707070707070707",
 					userIdentity:
 						"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858"
 				}
@@ -1780,7 +1840,7 @@ describe("AuditableItemGraphService", () => {
 		});
 
 		const changesetStore = changesetStorage.getStore();
-		expect(changesetStore).toMatchObject([
+		expect(changesetStore).toEqual([
 			{
 				id: "0202020202020202020202020202020202020202020202020202020202020202",
 				vertexId: "0101010101010101010101010101010101010101010101010101010101010101",
@@ -1839,6 +1899,7 @@ describe("AuditableItemGraphService", () => {
 				proofId: "immutable-proof:0303030303030303030303030303030303030303030303030303030303030303"
 			},
 			{
+				id: "0606060606060606060606060606060606060606060606060606060606060606",
 				vertexId: "0101010101010101010101010101010101010101010101010101010101010101",
 				dateCreated: "2024-08-22T11:56:56.272Z",
 				userIdentity:
@@ -1861,17 +1922,22 @@ describe("AuditableItemGraphService", () => {
 						path: "/resources/1/resourceObject/object/content",
 						value: "This is a simple note resource 11"
 					}
-				]
+				],
+				proofId: "immutable-proof:0707070707070707070707070707070707070707070707070707070707070707"
 			}
 		]);
 
 		const immutableStore = verifiableStorage.getStore();
-		expect(immutableStore).toMatchObject([
+		expect(immutableStore).toEqual([
 			{
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMiLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6b1p4M0xXYURKVG5iZU1qRkZGMU5ZTGhKUXpjd1F5S2NLZHdVeEpuNkRMQThZZlNCSkQ3QU1vOHNwTEc2U0pWc2JncHFlZzFvVmZkTFdqZkRQMkNtTTNVIiwidmVyaWZpY2F0aW9uTWV0aG9kIjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MyNpbW11dGFibGUtcHJvb2YtYXNzZXJ0aW9uIn0sInByb29mT2JqZWN0SGFzaCI6InNoYTI1NjpnejdkTGlHd1BaQ3BQbXF1T3JCUXk0N2JOcFBXZDhUSXdnK2J3aFg3ckVnPSIsInByb29mT2JqZWN0SWQiOiJhaWc6MDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTpjaGFuZ2VzZXQ6MDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMiJ9",
+				id: "0505050505050505050505050505050505050505050505050505050505050505",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			},
 			{
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDciLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6NG82WjR1b2NoRDlFWFh5d3RUYzd0VWVlVHRpTkQ0TTZ0clhyU3c0OUhDdVJRYzljRUs4aTlHOFp0ZnQzdWlNVld6dW9BMjJhR1BacUZwRE5pS3c4anZiVyIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDplbnRpdHktc3RvcmFnZToweDYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjMjaW1tdXRhYmxlLXByb29mLWFzc2VydGlvbiJ9LCJwcm9vZk9iamVjdEhhc2giOiJzaGEyNTY6dUFVUXErL0JUdGd6T083eUIvVXdXcSsyT2xZSUpXSkw3VHYzN2JBOExzaz0iLCJwcm9vZk9iamVjdElkIjoiYWlnOjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDE6Y2hhbmdlc2V0OjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYifQ==",
+				id: "0909090909090909090909090909090909090909090909090909090909090909",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			}
@@ -1880,7 +1946,7 @@ describe("AuditableItemGraphService", () => {
 		let immutableProof = ObjectHelper.fromBytes<IImmutableProof>(
 			Converter.base64ToBytes(immutableStore[0].data)
 		);
-		expect(immutableProof).toMatchObject({
+		expect(immutableProof).toEqual({
 			"@context": [
 				"https://schema.twindev.org/immutable-proof/",
 				"https://schema.twindev.org/common/",
@@ -1891,10 +1957,13 @@ describe("AuditableItemGraphService", () => {
 			proofObjectHash: "sha256:gz7dLiGwPZCpPmquOrBQy47bNpPWd8TIwg+bwhX7rEg=",
 			proofObjectId:
 				"aig:0101010101010101010101010101010101010101010101010101010101010101:changeset:0202020202020202020202020202020202020202020202020202020202020202",
+			nodeIdentity:
+				"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363",
 			userIdentity:
 				"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 			proof: {
 				type: "DataIntegrityProof",
+				created: "2024-08-22T11:56:56.272Z",
 				cryptosuite: "eddsa-jcs-2022",
 				proofPurpose: "assertionMethod",
 				proofValue:
@@ -1907,25 +1976,31 @@ describe("AuditableItemGraphService", () => {
 		immutableProof = ObjectHelper.fromBytes<IImmutableProof>(
 			Converter.base64ToBytes(immutableStore[1].data)
 		);
-		expect(immutableProof).toMatchObject({
+		expect(immutableProof).toEqual({
 			"@context": [
 				"https://schema.twindev.org/immutable-proof/",
 				"https://schema.twindev.org/common/",
 				"https://www.w3.org/ns/credentials/v2"
 			],
 			type: "ImmutableProof",
-			proofObjectHash: "sha256:TrY9E2Kr+SYrcEpSZzR3ZEh4TpQRK29NNoNOkrlQMuo=",
+			id: "0707070707070707070707070707070707070707070707070707070707070707",
+			nodeIdentity:
+				"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363",
 			userIdentity:
 				"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 			proof: {
 				type: "DataIntegrityProof",
+				created: "2024-08-22T11:56:56.272Z",
 				cryptosuite: "eddsa-jcs-2022",
 				proofPurpose: "assertionMethod",
 				proofValue:
-					"z591VqHL1GGGAxVth1qTwRkNFESpB8MzcTiwQ2LquUh49fP8tqWYATS46TgiXpsktvhY479axMNc2A9CCWc4YAJdC",
+					"z4o6Z4uochD9EXXywtTc7tUeeTtiND4M6trXrSw49HCuRQc9cEK8i9G8Ztft3uiMVWzuoA22aGPZqFpDNiKw8jvbW",
 				verificationMethod:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363#immutable-proof-assertion"
-			}
+			},
+			proofObjectHash: "sha256:uAUQq+/BTtgzOO7yB/UwWq+2OlYIJWJL7Tv37bA8Lsk=",
+			proofObjectId:
+				"aig:0101010101010101010101010101010101010101010101010101010101010101:changeset:0606060606060606060606060606060606060606060606060606060606060606"
 		});
 	});
 
@@ -1993,7 +2068,7 @@ describe("AuditableItemGraphService", () => {
 			verifySignatureDepth: VerifyDepth.All
 		});
 
-		expect(result).toMatchObject({
+		expect(result).toEqual({
 			"@context": [
 				"https://schema.twindev.org/aig/",
 				"https://schema.twindev.org/common/",
@@ -2036,6 +2111,7 @@ describe("AuditableItemGraphService", () => {
 				},
 				{
 					type: "AuditableItemGraphChangeset",
+					id: "0606060606060606060606060606060606060606060606060606060606060606",
 					dateCreated: "2024-08-22T11:56:56.272Z",
 					patches: [
 						{
@@ -2058,6 +2134,8 @@ describe("AuditableItemGraphService", () => {
 						}
 					],
 					verification: { type: "ImmutableProofVerification", verified: true },
+					proofId:
+						"immutable-proof:0707070707070707070707070707070707070707070707070707070707070707",
 					userIdentity:
 						"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858"
 				}
@@ -2085,7 +2163,7 @@ describe("AuditableItemGraphService", () => {
 
 		const changesetStore = changesetStorage.getStore();
 
-		expect(changesetStore).toMatchObject([
+		expect(changesetStore).toEqual([
 			{
 				id: "0202020202020202020202020202020202020202020202020202020202020202",
 				vertexId: "0101010101010101010101010101010101010101010101010101010101010101",
@@ -2116,6 +2194,7 @@ describe("AuditableItemGraphService", () => {
 			},
 			{
 				vertexId: "0101010101010101010101010101010101010101010101010101010101010101",
+				id: "0606060606060606060606060606060606060606060606060606060606060606",
 				dateCreated: "2024-08-22T11:56:56.272Z",
 				userIdentity:
 					"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
@@ -2127,7 +2206,8 @@ describe("AuditableItemGraphService", () => {
 						value: "This is a simple note 2"
 					},
 					{ op: "replace", path: "/edges/0/edgeRelationships/0", value: "frenemy" }
-				]
+				],
+				proofId: "immutable-proof:0707070707070707070707070707070707070707070707070707070707070707"
 			}
 		]);
 	});
@@ -2404,7 +2484,7 @@ describe("AuditableItemGraphService", () => {
 			verifySignatureDepth: VerifyDepth.All
 		});
 
-		expect(result).toMatchObject({
+		expect(result).toEqual({
 			"@context": [
 				"https://schema.twindev.org/aig/",
 				"https://schema.twindev.org/common/",
@@ -2559,6 +2639,7 @@ describe("AuditableItemGraphService", () => {
 				},
 				{
 					type: "AuditableItemGraphChangeset",
+					id: "0606060606060606060606060606060606060606060606060606060606060606",
 					dateCreated: "2024-08-22T11:56:56.272Z",
 					patches: [
 						{
@@ -2641,6 +2722,8 @@ describe("AuditableItemGraphService", () => {
 						}
 					],
 					verification: { type: "ImmutableProofVerification", verified: true },
+					proofId:
+						"immutable-proof:0707070707070707070707070707070707070707070707070707070707070707",
 					userIdentity:
 						"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858"
 				}
@@ -2716,7 +2799,7 @@ describe("AuditableItemGraphService", () => {
 		});
 
 		const changesetStore = changesetStorage.getStore();
-		expect(changesetStore).toMatchObject([
+		expect(changesetStore).toEqual([
 			{
 				id: "0202020202020202020202020202020202020202020202020202020202020202",
 				vertexId: "0101010101010101010101010101010101010101010101010101010101010101",
@@ -2826,6 +2909,7 @@ describe("AuditableItemGraphService", () => {
 			},
 			{
 				vertexId: "0101010101010101010101010101010101010101010101010101010101010101",
+				id: "0606060606060606060606060606060606060606060606060606060606060606",
 				dateCreated: "2024-08-22T11:56:56.272Z",
 				userIdentity:
 					"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
@@ -2871,17 +2955,22 @@ describe("AuditableItemGraphService", () => {
 						path: "/edges/1/annotationObject/object/content",
 						value: "This is a simple note edge 20"
 					}
-				]
+				],
+				proofId: "immutable-proof:0707070707070707070707070707070707070707070707070707070707070707"
 			}
 		]);
 
 		const immutableStore = verifiableStorage.getStore();
-		expect(immutableStore).toMatchObject([
+		expect(immutableStore).toEqual([
 			{
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMwMzAzMDMiLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6M0NmaFphdFF0N3BTN1Fxa0pHY1lnN2ZmTWh6VUtqOVdENXlVbTNVQjZUVWR4dHA0RVdMQWh1U1B0VWNBaDh3NGk1ODU5MUFZUmFDRUpzWXFMdTloc3Q1ViIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDplbnRpdHktc3RvcmFnZToweDYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjMjaW1tdXRhYmxlLXByb29mLWFzc2VydGlvbiJ9LCJwcm9vZk9iamVjdEhhc2giOiJzaGEyNTY6SUU3V0d6TWRDc2dkc3pPUzV0QWRWN2d6RFl1NDJTV2JKT3p1SnBodytibz0iLCJwcm9vZk9iamVjdElkIjoiYWlnOjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDE6Y2hhbmdlc2V0OjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIwMjAyMDIifQ==",
+				id: "0505050505050505050505050505050505050505050505050505050505050505",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			},
 			{
+				data: "eyJAY29udGV4dCI6WyJodHRwczovL3NjaGVtYS50d2luZGV2Lm9yZy9pbW11dGFibGUtcHJvb2YvIiwiaHR0cHM6Ly9zY2hlbWEudHdpbmRldi5vcmcvY29tbW9uLyIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiJdLCJpZCI6IjA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDcwNzA3MDciLCJ0eXBlIjoiSW1tdXRhYmxlUHJvb2YiLCJub2RlSWRlbnRpdHkiOiJkaWQ6ZW50aXR5LXN0b3JhZ2U6MHg2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzIiwidXNlcklkZW50aXR5IjoiZGlkOmVudGl0eS1zdG9yYWdlOjB4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1ODU4NTg1OCIsInByb29mIjp7InR5cGUiOiJEYXRhSW50ZWdyaXR5UHJvb2YiLCJjcmVhdGVkIjoiMjAyNC0wOC0yMlQxMTo1Njo1Ni4yNzJaIiwiY3J5cHRvc3VpdGUiOiJlZGRzYS1qY3MtMjAyMiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJ6NGdtb0ZhSnhtRm1kdmMzSm1QV01MZDhQSGQzRGV0NDI4VDNHV2NLU3JWZnROamtCTVBxb3g2UVFMbVdpVUpudEJSQVlZV3VRSERxNzJWMldvaEFjcXVHMSIsInZlcmlmaWNhdGlvbk1ldGhvZCI6ImRpZDplbnRpdHktc3RvcmFnZToweDYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjM2MzYzNjMjaW1tdXRhYmxlLXByb29mLWFzc2VydGlvbiJ9LCJwcm9vZk9iamVjdEhhc2giOiJzaGEyNTY6TkkzYTNhT0Vya1gwNDNLcmthUzBLK3NWZE85dGtCUjZYVURlZHkyTkxKND0iLCJwcm9vZk9iamVjdElkIjoiYWlnOjAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDE6Y2hhbmdlc2V0OjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYwNjA2MDYifQ==",
+				id: "0909090909090909090909090909090909090909090909090909090909090909",
 				controller:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363"
 			}
@@ -2890,7 +2979,7 @@ describe("AuditableItemGraphService", () => {
 		let immutableProof = ObjectHelper.fromBytes<IImmutableProof>(
 			Converter.base64ToBytes(immutableStore[0].data)
 		);
-		expect(immutableProof).toMatchObject({
+		expect(immutableProof).toEqual({
 			"@context": [
 				"https://schema.twindev.org/immutable-proof/",
 				"https://schema.twindev.org/common/",
@@ -2901,10 +2990,13 @@ describe("AuditableItemGraphService", () => {
 			proofObjectHash: "sha256:IE7WGzMdCsgdszOS5tAdV7gzDYu42SWbJOzuJphw+bo=",
 			proofObjectId:
 				"aig:0101010101010101010101010101010101010101010101010101010101010101:changeset:0202020202020202020202020202020202020202020202020202020202020202",
+			nodeIdentity:
+				"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363",
 			userIdentity:
 				"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 			proof: {
 				type: "DataIntegrityProof",
+				created: "2024-08-22T11:56:56.272Z",
 				cryptosuite: "eddsa-jcs-2022",
 				proofPurpose: "assertionMethod",
 				proofValue:
@@ -2917,22 +3009,28 @@ describe("AuditableItemGraphService", () => {
 		immutableProof = ObjectHelper.fromBytes<IImmutableProof>(
 			Converter.base64ToBytes(immutableStore[1].data)
 		);
-		expect(immutableProof).toMatchObject({
+		expect(immutableProof).toEqual({
 			"@context": [
 				"https://schema.twindev.org/immutable-proof/",
 				"https://schema.twindev.org/common/",
 				"https://www.w3.org/ns/credentials/v2"
 			],
 			type: "ImmutableProof",
-			proofObjectHash: "sha256:nbAKN2Rxdk1NfKl77bQIn9ht4zoPT0HyEtsoVHTaI6o=",
+			proofObjectHash: "sha256:NI3a3aOErkX043KrkaS0K+sVdO9tkBR6XUDedy2NLJ4=",
+			proofObjectId:
+				"aig:0101010101010101010101010101010101010101010101010101010101010101:changeset:0606060606060606060606060606060606060606060606060606060606060606",
+			id: "0707070707070707070707070707070707070707070707070707070707070707",
+			nodeIdentity:
+				"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363",
 			userIdentity:
 				"did:entity-storage:0x5858585858585858585858585858585858585858585858585858585858585858",
 			proof: {
 				type: "DataIntegrityProof",
+				created: "2024-08-22T11:56:56.272Z",
 				cryptosuite: "eddsa-jcs-2022",
 				proofPurpose: "assertionMethod",
 				proofValue:
-					"z4JVRFoxtWmkRs1XTP6orRsP2Pdwub3BJxHuakzBc6VS5m1uAG7xXf1AznJz7NAR97BSXFpqE5p1maktHgFJWNzBF",
+					"z4gmoFaJxmFmdvc3JmPWMLd8PHd3Det428T3GWcKSrVftNjkBMPqox6QQLmWiUJntBRAYYWuQHDq72V2WohAcquG1",
 				verificationMethod:
 					"did:entity-storage:0x6363636363636363636363636363636363636363636363636363636363636363#immutable-proof-assertion"
 			}
@@ -3015,7 +3113,7 @@ describe("AuditableItemGraphService", () => {
 
 		const results = await service.query({ id: "0" });
 
-		expect(results).toMatchObject({
+		expect(results).toEqual({
 			"@context": [
 				"https://schema.twindev.org/aig/",
 				"https://schema.twindev.org/common/",
@@ -3025,6 +3123,7 @@ describe("AuditableItemGraphService", () => {
 			vertices: [
 				{
 					type: "AuditableItemGraphVertex",
+					id: "aig:0606060606060606060606060606060606060606060606060606060606060606",
 					dateCreated: "2024-08-22T11:56:56.272Z"
 				},
 				{
@@ -3054,7 +3153,7 @@ describe("AuditableItemGraphService", () => {
 		);
 
 		const results = await service.query({ id: "foo" });
-		expect(results).toMatchObject({
+		expect(results).toEqual({
 			"@context": [
 				"https://schema.twindev.org/aig/",
 				"https://schema.twindev.org/common/",
@@ -3064,6 +3163,7 @@ describe("AuditableItemGraphService", () => {
 			vertices: [
 				{
 					type: "AuditableItemGraphVertex",
+					id: "aig:0606060606060606060606060606060606060606060606060606060606060606",
 					dateCreated: "2024-08-22T11:56:56.272Z",
 					aliases: [
 						{
@@ -3120,11 +3220,6 @@ describe("AuditableItemGraphService", () => {
 			type: "AuditableItemGraphVertexList",
 			vertices: [
 				{
-					id: "aig:0505050505050505050505050505050505050505050505050505050505050505",
-					type: "AuditableItemGraphVertex",
-					dateCreated: "2024-08-22T11:56:56.272Z"
-				},
-				{
 					id: "aig:0101010101010101010101010101010101010101010101010101010101010101",
 					type: "AuditableItemGraphVertex",
 					dateCreated: "2024-08-22T11:55:16.271Z",
@@ -3147,7 +3242,7 @@ describe("AuditableItemGraphService", () => {
 		);
 		await service.create({}, TEST_USER_IDENTITY, TEST_NODE_IDENTITY);
 
-		const results = await service.query({ id: "5", idMode: "id" });
+		const results = await service.query({ id: "6", idMode: "id" });
 		expect(results).toEqual({
 			"@context": [
 				"https://schema.twindev.org/aig/",
@@ -3157,7 +3252,7 @@ describe("AuditableItemGraphService", () => {
 			type: "AuditableItemGraphVertexList",
 			vertices: [
 				{
-					id: "aig:0505050505050505050505050505050505050505050505050505050505050505",
+					id: "aig:0606060606060606060606060606060606060606060606060606060606060606",
 					type: "AuditableItemGraphVertex",
 					dateCreated: "2024-08-22T11:56:56.272Z"
 				}


### PR DESCRIPTION
The new deterministic background tasks failed with the tests as the ids were different, we have replace the `matchObject` calls with `equals` in the tests to perform much stricter checks on the data.